### PR TITLE
Bugfix/4 gdal proj errors

### DIFF
--- a/exe/hooks/hook-natcap.root.py
+++ b/exe/hooks/hook-natcap.root.py
@@ -1,0 +1,5 @@
+from PyInstaller.utils.hooks import (
+    collect_submodules, collect_data_files, copy_metadata)
+
+datas = collect_data_files('natcap.root') + copy_metadata('natcap.root')
+hiddenimports = collect_submodules('natcap.root')

--- a/exe/root.spec
+++ b/exe/root.spec
@@ -42,7 +42,8 @@ a = Analysis([os.path.join(os.getcwd(), 'natcap', 'root', 'root.py')],  # Assume
                 'cmath',
              ],
              hookspath=[os.path.join(os.getcwd(), 'exe', 'hooks')],
-             runtime_hooks=None,
+             runtime_hooks=os.path.join(
+                os.getcwd(), 'exe', 'hooks', 'rthook.py'),
              excludes=None,
              win_no_prefer_redirects=None,
              win_private_assemblies=None,

--- a/exe/root.spec
+++ b/exe/root.spec
@@ -42,8 +42,8 @@ a = Analysis([os.path.join(os.getcwd(), 'natcap', 'root', 'root.py')],  # Assume
                 'cmath',
              ],
              hookspath=[os.path.join(os.getcwd(), 'exe', 'hooks')],
-             runtime_hooks=os.path.join(
-                os.getcwd(), 'exe', 'hooks', 'rthook.py'),
+             runtime_hooks=[os.path.join(
+                os.getcwd(), 'exe', 'hooks', 'rthook.py')],
              excludes=None,
              win_no_prefer_redirects=None,
              win_private_assemblies=None,

--- a/natcap/root/__init__.py
+++ b/natcap/root/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+import pkg_resources
+
 LOGGER = logging.getLogger('natcap.root')
 LOGGER.addHandler(logging.NullHandler())
 

--- a/natcap/root/__init__.py
+++ b/natcap/root/__init__.py
@@ -1,0 +1,10 @@
+import logging
+
+LOGGER = logging.getLogger('natcap.root')
+LOGGER.addHandler(logging.NullHandler())
+
+try:
+    __version__ = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
+    # package is not installed.  Log the exception for debugging.
+    LOGGER.exception('Could not load natcap.root version information')

--- a/natcap/root/arith_parser.py
+++ b/natcap/root/arith_parser.py
@@ -3,7 +3,6 @@
 
 import operator
 import numpy as np
-import pandas as pd
 
 
 FUNCTIONS = ['abs', 'log', 'sqrt', 'sum', 'min', 'max']

--- a/natcap/root/optim_core.py
+++ b/natcap/root/optim_core.py
@@ -13,11 +13,8 @@ These are:
 
 import os
 import copy
-import sys
 import glob
 import json
-import datetime
-import pprint
 import warnings
 from collections import namedtuple
 import cvxpy as cvx

--- a/natcap/root/preprocessing.py
+++ b/natcap/root/preprocessing.py
@@ -118,10 +118,9 @@ def execute(args):
         return array
 
     pygeoprocessing.raster_calculator(
-       [(args['potential_conversion_mask_path'], 1)],
+       [(args['mask_raster'], 1)],
         _foo, os.path.join(args['workspace_dir'], 'foo.tif'),
         gdal.GDT_Float32, -1)
-
 
     # Create merged activity mask
     mask_path_list = args['activity_masks'].values()

--- a/natcap/root/preprocessing.py
+++ b/natcap/root/preprocessing.py
@@ -10,7 +10,6 @@ import math
 import tempfile
 import collections
 import glob
-import json
 import shapely.wkb
 import shapely.prepared
 
@@ -240,7 +239,6 @@ def _serviceshed_coverage(
     result = collections.defaultdict(
         lambda: collections.defaultdict(
             lambda: [0.0, collections.defaultdict(float)]))
-
 
     for serviceshed_id, serviceshed_path in zip(
             serviceshed_id_list, serviceshed_path_list):
@@ -911,7 +909,6 @@ def _create_overlapping_activity_mask(mask_path_list, target_file,
 
     ref_info = pygeoprocessing.get_raster_info(mask_path_list[reference_mask])
     ref_nodata = ref_info['nodata'][0]
-    pixel_size = ref_info['pixel_size']
 
     # Align stack to the reference dataset's bounding box using
     # nearest-neighbor interpolation.
@@ -930,7 +927,7 @@ def _create_overlapping_activity_mask(mask_path_list, target_file,
         for index, array in enumerate(vals):
             # numpy.isclose will work for floating-point and integer rasters,
             # direct equality comparison will not.
-            pixels_with_complete_overlap  &= numpy.isclose(
+            pixels_with_complete_overlap &= numpy.isclose(
                 array, mask_nodatas[index])
 
         output_array = numpy.full(pixels_with_complete_overlap.shape,

--- a/natcap/root/preprocessing.py
+++ b/natcap/root/preprocessing.py
@@ -119,7 +119,7 @@ def execute(args):
 
     pygeoprocessing.raster_calculator(
        [(args['mask_raster'], 1)],
-        _foo, os.path.join(args['workspace_dir'], 'foo.tif'),
+        _foo, os.path.join(args['workspace'], 'foo.tif'),
         gdal.GDT_Float32, -1)
 
     # Create merged activity mask

--- a/natcap/root/preprocessing.py
+++ b/natcap/root/preprocessing.py
@@ -109,19 +109,6 @@ def execute(args):
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
 
-    # TODO: Remove this raster_calculator call.
-    # This raster_calculator_call is just to try and trigger the proj.db
-    # issue on Windows in the binary build.  It can and should be removed
-    # once the issue at https://github.com/natcap/ROOT/issues/4 is
-    # resolved.
-    def _foo(array):
-        return array
-
-    pygeoprocessing.raster_calculator(
-       [(args['mask_raster'], 1)],
-        _foo, os.path.join(args['workspace'], 'foo.tif'),
-        gdal.GDT_Float32, -1)
-
     # Create merged activity mask
     mask_path_list = args['activity_masks'].values()
     all_activity_mask = os.path.join(args['workspace'], 'all_activity_mask.tif')

--- a/natcap/root/preprocessing.py
+++ b/natcap/root/preprocessing.py
@@ -109,6 +109,20 @@ def execute(args):
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
 
+    # TODO: Remove this raster_calculator call.
+    # This raster_calculator_call is just to try and trigger the proj.db
+    # issue on Windows in the binary build.  It can and should be removed
+    # once the issue at https://github.com/natcap/ROOT/issues/4 is
+    # resolved.
+    def _foo(array):
+        return array
+
+    pygeoprocessing.raster_calculator(
+       [(args['potential_conversion_mask_path'], 1)],
+        _foo, os.path.join(args['workspace_dir'], 'foo.tif'),
+        gdal.GDT_Float32, -1)
+
+
     # Create merged activity mask
     mask_path_list = args['activity_masks'].values()
     all_activity_mask = os.path.join(args['workspace'], 'all_activity_mask.tif')

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -119,7 +119,7 @@ ARGS_SPEC = {
         },
         'spatial_decision_unit_area': {
             'type': 'number',
-            'required': True,
+            'required': False,
             'about': (
                 "Area of each grid cell in the constructed grid. "
                 "Measured in hectares (1 ha = 10,000m^2). This is "

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -17,10 +17,11 @@ import PySide2  # pragma: no cover
 from qtpy import QtWidgets
 from qtpy import QtGui
 from natcap.invest.ui import model, inputs
+from natcap.invest import validation
 
 sys.path.extend([os.getcwd()])
 
-from natcap.invest import validation
+from natcap.root import __version__
 from natcap.root import preprocessing
 from natcap.root import postprocessing
 from natcap.root import optimization
@@ -210,7 +211,7 @@ def execute(args):
     """root.
 
     """
-
+    LOGGER.info(f'Running ROOT version {__version__}')
     internal_args = parse_args(args)
 
     # with open(os.path.join(internal_args['workspace'], 'root_args.json'), 'w') as root_args_file:

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -298,7 +298,7 @@ def parse_args(ui_args):
         # TODO: this should be optional, too.
         combined_factors = {}
         if 'combined_factor_table_path' in ui_args and os.path.isfile(ui_args['combined_factor_table_path']):
-            with open(ui_args['combined_factor_table_path'], 'rU') as tablefile:
+            with open(ui_args['combined_factor_table_path'], 'r') as tablefile:
                 reader = csv.DictReader(tablefile)
                 for row in reader:
                     combined_factors[row['name']] = [x.strip() for x in row['factors'].split(' ')]
@@ -383,7 +383,7 @@ def _process_raster_table(filename):
             self.filepath = filepath
             self.raster_lookup = {}
             self.factor_names = []
-            with open(filename, 'rU') as tablefile:
+            with open(filename, 'r') as tablefile:
                 header = tablefile.readline()
                 header_fields = [f.strip() for f in header.split(',')]
                 assert header_fields[0] == 'name'
@@ -424,7 +424,7 @@ def _process_objectives_table(ui_args, root_args):
         optimization_objectives = {}
         min_choices = ['Minimize', 'minimize', 'Min', 'min', 'Minimum', 'minimum']
         max_choices = ['Maximize', 'maximize', 'Max', 'max', 'Maximum', 'maximum']
-        with open(ui_args['objectives_table_path'], 'rU') as tablefile:
+        with open(ui_args['objectives_table_path'], 'r') as tablefile:
             var_names = tablefile.readline().strip().split(',')
             minmax = tablefile.readline().strip().split(',')
             for v, mm in zip(var_names, minmax):

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -248,19 +248,6 @@ def parse_args(ui_args):
 
     if ui_args['do_preprocessing']:
 
-        # TODO: Remove this raster_calculator call.
-        # This raster_calculator_call is just to try and trigger the proj.db
-        # issue on Windows in the binary build.  It can and should be removed
-        # once the issue at https://github.com/natcap/ROOT/issues/4 is
-        # resolved.
-        def _foo(array):
-            return array
-
-        pygeoprocessing.raster_calculator(
-            [(ui_args['potential_conversion_mask_path'], 1)],
-            _foo, os.path.join(ui_args['workspace_dir'], 'foo.tif'),
-            gdal.GDT_Float32, -1)
-
         validate_raster_input_table(ui_args['marginal_raster_table_path'])
         validate_shapefile_input_table(ui_args['serviceshed_shapefiles_table'])
         validate_cft_table(ui_args['marginal_raster_table_path'],

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -255,11 +255,11 @@ def parse_args(ui_args):
 
         root_args['mask_raster'] = ui_args['potential_conversion_mask_path']
         root_args['grid_type'] = ui_args['spatial_decision_unit_shape']
-        cell_area = ui_args['spatial_decision_unit_area'] * 10000
+        cell_area = float(ui_args['spatial_decision_unit_area']) * 10000
         if root_args['grid_type'] == 'square':
             root_args['cell_size'] = sqrt(cell_area)
         elif root_args['grid_type'] == 'hexagon':
-            a = sqrt( (2*cell_area) / (3*sqrt(3)) )
+            a = sqrt((2*cell_area) / (3*sqrt(3)))
             root_args['cell_size'] = 2 * a
 
         root_args['csv_output_folder'] = os.path.join(root_args['workspace'], 'sdu_value_tables')

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -3,23 +3,17 @@
 import os
 import sys
 import logging
-import collections
 import csv
-import uuid
-import json
 import multiprocessing
 from math import sqrt
 
 import pandas as pd
 from osgeo import ogr
-from osgeo import gdal
 import PySide2  # pragma: no cover
 from qtpy import QtWidgets
 from qtpy import QtGui
 from natcap.invest.ui import model, inputs
 from natcap.invest import validation
-
-sys.path.extend([os.getcwd()])
 
 from natcap.root import __version__
 from natcap.root import preprocessing
@@ -571,7 +565,6 @@ def validate(args, limit_to=None):
         args, ARGS_SPEC['args'], ARGS_SPEC['args_with_spatial_overlap'])
 
     invalid_keys = validation.get_invalid_keys(validation_warnings)
-    sufficient_keys = validation.get_sufficient_keys(args)
 
     if 'spatial_decision_unit_shape' not in invalid_keys:
         sdu_valid = True

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -9,11 +9,13 @@ from math import sqrt
 
 import pandas as pd
 from osgeo import ogr
+from osgeo import gdal
 import PySide2  # pragma: no cover
 from qtpy import QtWidgets
 from qtpy import QtGui
 from natcap.invest.ui import model, inputs
 from natcap.invest import validation
+import pygeoprocessing
 
 from natcap.root import __version__
 from natcap.root import preprocessing
@@ -245,6 +247,19 @@ def parse_args(ui_args):
     root_args['sdu_id_col'] = 'SDU_ID'
 
     if ui_args['do_preprocessing']:
+
+        # TODO: Remove this raster_calculator call.
+        # This raster_calculator_call is just to try and trigger the proj.db
+        # issue on Windows in the binary build.  It can and should be removed
+        # once the issue at https://github.com/natcap/ROOT/issues/4 is
+        # resolved.
+        def _foo(array):
+            return array
+
+        pygeoprocessing.raster_calculator(
+            [(ui_args['potential_conversion_mask_path'], 1)],
+            _foo, os.path.join(ui_args['workspace_dir'], 'foo.tif'),
+            gdal.GDT_Float32, -1)
 
         validate_raster_input_table(ui_args['marginal_raster_table_path'])
         validate_shapefile_input_table(ui_args['serviceshed_shapefiles_table'])

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -606,6 +606,13 @@ class Root(model.InVESTModel):
             localdoc=u'../documentation/root.html'
         )
 
+        # Explicitly setting the default workspace because the InVEST UI's
+        # approach relies on self.target.__module__, which isn't reliable when
+        # execute is in the same script as the launcher.  In this case, the
+        # module name is __main__.  Technically true, but not user-readable.
+        self.workspace.set_value(os.path.normpath(
+            os.path.expanduser('~/Documents/root_workspace')))
+
         self.preprocessing_container = inputs.Container(
             args_key=u'preprocessing_container',
             expandable=False,

--- a/natcap/root/root.py
+++ b/natcap/root/root.py
@@ -111,7 +111,7 @@ ARGS_SPEC = {
             'name': 'Activity Mask Raster',
         },
         'spatial_decision_unit_shape': {
-            'type': 'vector',
+            'type': 'freestyle_string',
             'required': True,
             'about': (
                 "Determines the shape of the SDUs used to aggregate "
@@ -567,8 +567,27 @@ def validate_objectives_and_constraints_tables(obj_table_file, cons_table_file, 
 
 
 def validate(args, limit_to=None):
-    return validation.validate(
+    validation_warnings = validation.validate(
         args, ARGS_SPEC['args'], ARGS_SPEC['args_with_spatial_overlap'])
+
+    invalid_keys = validation.get_invalid_keys(validation_warnings)
+    sufficient_keys = validation.get_sufficient_keys(args)
+
+    if 'spatial_decision_unit_shape' not in invalid_keys:
+        sdu_valid = True
+        try:
+            if not validate_sdu_shape_arg(args['spatial_decision_unit_shape']):
+                sdu_valid = False
+        except RootInputError:
+            sdu_valid = False
+
+        if not sdu_valid:
+            validation_warnings.append(
+                (['spatial_decision_unit_shape'],
+                 ('Spatial Decision Unit Shape must be "square", "hexagon", '
+                  'or a path to a vector')))
+
+    return validation_warnings
 
 
 def _create_input_kwargs_from_args_spec(args_key, validate=True):

--- a/natcap/root/stats.py
+++ b/natcap/root/stats.py
@@ -1,12 +1,8 @@
-import sys
 import os
 import glob
-import json
-import copy
 
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 
 
 def load_sols(opt_folder, cols, sol_file_str='solution_*.csv'):
@@ -111,15 +107,3 @@ def bootstrap_mean_variance_from_sample(amap_sample):
 def bootstrap_mean_variance_from_sols(sols, ppm, nsamps):
     sample = make_agreement_map_sample(sols, ppm, nsamps)
     return bootstrap_mean_variance_from_sample(sample)
-
-
-
-
-
-
-
-
-
-
-
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pyinstaller==3.5
+pyinstaller>=4.1  # match natcap.invest==3.9.0
 setuptools_scm
 cython
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ qtawesome
 Shapely
 requests
 pygeoprocessing
+gdal<3.3.0  # GDAL won't currently import with GDAL 3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ qtawesome
 Shapely
 requests
 pygeoprocessing
-gdal<3.3.0  # GDAL won't currently import with GDAL 3.3.0
+gdal<3.3.0  # pygeoprocessing won't currently import with GDAL 3.3.0


### PR DESCRIPTION
This PR fixes #4 and also fixes #1 .  The issue with #4 was ultimately that, while the runtime hook `exe/hooks/rthook.py` was present and correct, the runtime hook was not actually being used in `exe/root.spec`.  The end result of this mistake being that `PROJ_LIB` wasn't defined as an environment variable, so `proj.db` couldn't be found by GDAL.

While working on this, I also made a couple of small improvements that I hope will improve our lives as maintainers in the longer-run:

1. The ROOT version is now included in the logfile.  For InVEST, this version string has been _super_ helpful for debugging issues (and distinguishing logfiles), so this will probably be the case for ROOT as well.
2. Validation of the spatial decision unit shape now correctly allows for the three possible values defined in the docstring.
3. Removed the deprecated `"U"` flag from calls to `open`.  This was [deprecated in 3.4 and will be removed in 3.10.](https://docs.python.org/3/library/functions.html#open)
4. Mild linting/PEP8

While working on this issue, I also encountered #6 . I doubt this will be hard to address, but I don't have the context needed at the moment to address it properly.