### PR TITLE
Use a dropdown in place of a text field and fix validation

### DIFF
--- a/natcap/root/__main__.py
+++ b/natcap/root/__main__.py
@@ -1,0 +1,4 @@
+from . import root
+
+if __name__ == '__main__':
+    root.main()


### PR DESCRIPTION
This came up on the [NatCap Forum ](https://community.naturalcapitalproject.org/t/root-error-analysis-type-invalid/4185/10) and is fixed by:

1. Correcting the `MODEL_SPEC` to use the correct options for an `option_string`
2. Using a dropdown instead of a text field because the content is one of a few option strings anyways.

I also added a `__main__.py`, which makes it easier to run within a virtualenv.  So you can now launch ROOT by `python -m natcap.root`.